### PR TITLE
Terraform 0 12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,16 +44,8 @@ module "vpc" {
 # assign new ones so you can test rules applied to individual subnets.
 resource "aws_network_acl" "private_subnet_acl" {
   # Fails with length() because these are computed values.
-  count  = "2"
-  vpc_id = module.vpc.vpc_id
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
+  count      = "2"
+  vpc_id     = module.vpc.vpc_id
   subnet_ids = [element(module.vpc.private_subnets, count.index)]
   tags       = module.vpc_label.tags
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 data "aws_ami" "amazon-linux-2" {
   most_recent = true
-  owners = ["amazon"]
+  owners      = ["amazon"]
 
   filter {
     name   = "name"
@@ -9,30 +9,31 @@ data "aws_ami" "amazon-linux-2" {
 }
 
 module "vpc_label" {
-  source             = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.5.3"
-  namespace          = "${var.namespace}"
-  environment        = "${var.environment}"
-  stage              = "${var.stage}"
-  name               = "vpc"
-  delimiter          = "${var.delimiter}"
-  attributes         = "${var.attributes}"
-  tags               = "${var.tags}"
-  additional_tag_map = "${var.additional_tag_map}"
-  context            = "${var.context}"
-  label_order        = "${var.label_order}"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.14.1"
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = "vpc"
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  context             = var.context
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
 }
 
 module "vpc" {
-  name   = "${module.vpc_label.id}"
-  tags   = "${module.vpc_label.tags}"
-  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.46.0"
+  name   = module.vpc_label.id
+  tags   = module.vpc_label.tags
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.9.0"
 
   azs                = ["${var.aws_region}a", "${var.aws_region}b"]
   cidr               = "10.0.0.0/22"
   enable_dns_support = "true"
 
   # So testa/b can install tools.
-  enable_nat_gateway      = "${var.enabled}"
+  enable_nat_gateway      = var.enabled
   single_nat_gateway      = "true"
   map_public_ip_on_launch = "false"
   private_subnets         = ["10.0.1.0/24", "10.0.2.0/24"]
@@ -43,10 +44,18 @@ module "vpc" {
 # assign new ones so you can test rules applied to individual subnets.
 resource "aws_network_acl" "private_subnet_acl" {
   # Fails with length() because these are computed values.
-  count      = "2"
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${element(module.vpc.private_subnets, count.index)}"]
-  tags       = "${module.vpc_label.tags}"
+  count  = "2"
+  vpc_id = module.vpc.vpc_id
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  subnet_ids = [element(module.vpc.private_subnets, count.index)]
+  tags       = module.vpc_label.tags
 
   # Allow SSH from bastion.
   ingress {
@@ -110,28 +119,29 @@ resource "aws_network_acl" "private_subnet_acl" {
     to_port    = 61000
   }
 
-  depends_on = ["module.vpc"]
+  depends_on = [module.vpc]
 }
 
 module "bastion_label" {
-  source             = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.5.3"
-  namespace          = "${var.namespace}"
-  environment        = "${var.environment}"
-  stage              = "${var.stage}"
-  name               = "bastion"
-  delimiter          = "${var.delimiter}"
-  attributes         = "${var.attributes}"
-  tags               = "${var.tags}"
-  additional_tag_map = "${var.additional_tag_map}"
-  context            = "${var.context}"
-  label_order        = "${var.label_order}"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.14.1"
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = "bastion"
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  context             = var.context
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
 }
 
 resource "aws_security_group" "bastion" {
-  name        = "${module.bastion_label.id}"
-  tags        = "${module.bastion_label.tags}"
+  name        = module.bastion_label.id
+  tags        = module.bastion_label.tags
   description = "Allow SSH from the public Internet."
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = module.vpc.vpc_id
 
   ingress {
     from_port   = 22
@@ -149,36 +159,37 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_instance" "bastion" {
-  count                       = "${var.enabled ? 1 : 0}"
-  ami                         = "${data.aws_ami.amazon-linux-2.image_id}"
+  count                       = var.enabled ? 1 : 0
+  ami                         = data.aws_ami.amazon-linux-2.image_id
   associate_public_ip_address = true
   instance_type               = "t2.micro"
-  key_name                    = "${var.key_name}"
-  subnet_id                   = "${module.vpc.public_subnets[0]}"
-  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+  key_name                    = var.key_name
+  subnet_id                   = module.vpc.public_subnets[0]
+  vpc_security_group_ids      = [aws_security_group.bastion.id]
 
-  tags = "${module.bastion_label.tags}"
+  tags = module.bastion_label.tags
 }
 
 module "testa_label" {
-  source             = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.5.3"
-  namespace          = "${var.namespace}"
-  environment        = "${var.environment}"
-  stage              = "${var.stage}"
-  name               = "testa"
-  delimiter          = "${var.delimiter}"
-  attributes         = "${var.attributes}"
-  tags               = "${var.tags}"
-  additional_tag_map = "${var.additional_tag_map}"
-  context            = "${var.context}"
-  label_order        = "${var.label_order}"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.14.1"
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = "testa"
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  context             = var.context
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
 }
 
 resource "aws_security_group" "testa" {
-  name        = "${module.testa_label.id}"
-  tags        = "${module.testa_label.tags}"
+  name        = module.testa_label.id
+  tags        = module.testa_label.tags
   description = "For the testa host."
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = module.vpc.vpc_id
 
   # Allow SSH from the public subnet (where the bastion runs).
   ingress {
@@ -212,35 +223,36 @@ resource "aws_security_group" "testa" {
 }
 
 resource "aws_instance" "testa" {
-  count                  = "${var.enabled ? 1 : 0}"
-  ami                    = "${data.aws_ami.amazon-linux-2.image_id}"
+  count                  = var.enabled ? 1 : 0
+  ami                    = data.aws_ami.amazon-linux-2.image_id
   instance_type          = "t2.micro"
-  key_name               = "${var.key_name}"
-  subnet_id              = "${module.vpc.private_subnets[0]}"
-  vpc_security_group_ids = ["${aws_security_group.testa.id}"]
+  key_name               = var.key_name
+  subnet_id              = module.vpc.private_subnets[0]
+  vpc_security_group_ids = [aws_security_group.testa.id]
 
-  tags = "${module.testa_label.tags}"
+  tags = module.testa_label.tags
 }
 
 module "testb_label" {
-  source             = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.5.3"
-  namespace          = "${var.namespace}"
-  environment        = "${var.environment}"
-  stage              = "${var.stage}"
-  name               = "testb"
-  delimiter          = "${var.delimiter}"
-  attributes         = "${var.attributes}"
-  tags               = "${var.tags}"
-  additional_tag_map = "${var.additional_tag_map}"
-  context            = "${var.context}"
-  label_order        = "${var.label_order}"
+  source              = "git::https://github.com/cloudposse/terraform-null-label.git?ref=0.14.1"
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = "testb"
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  context             = var.context
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
 }
 
 resource "aws_security_group" "testb" {
-  name        = "${module.testb_label.id}"
-  tags        = "${module.testb_label.tags}"
+  name        = module.testb_label.id
+  tags        = module.testb_label.tags
   description = "For the testb host."
-  vpc_id      = "${module.vpc.vpc_id}"
+  vpc_id      = module.vpc.vpc_id
 
   # Allow SSH from the public subnet (where the bastion runs).
   ingress {
@@ -274,12 +286,12 @@ resource "aws_security_group" "testb" {
 }
 
 resource "aws_instance" "testb" {
-  count                  = "${var.enabled ? 1 : 0}"
-  ami                    = "${data.aws_ami.amazon-linux-2.image_id}"
+  count                  = var.enabled ? 1 : 0
+  ami                    = data.aws_ami.amazon-linux-2.image_id
   instance_type          = "t2.micro"
-  key_name               = "${var.key_name}"
-  subnet_id              = "${module.vpc.private_subnets[1]}"
-  vpc_security_group_ids = ["${aws_security_group.testb.id}"]
+  key_name               = var.key_name
+  subnet_id              = module.vpc.private_subnets[1]
+  vpc_security_group_ids = [aws_security_group.testb.id]
 
-  tags = "${module.testb_label.tags}"
+  tags = module.testb_label.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,5 @@
-variable "aws_region" {}
+variable "aws_region" {
+}
 
 variable "enabled" {
   default     = true
@@ -11,46 +12,75 @@ variable "key_name" {
 
 # terraform-null-label inputs
 variable "namespace" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "environment" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "stage" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "delimiter" {
-  type    = "string"
+  type    = string
   default = "-"
 }
 
 variable "attributes" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
 variable "tags" {
-  type    = "map"
+  type    = map(string)
   default = {}
 }
 
 variable "additional_tag_map" {
-  type    = "map"
+  type    = map(string)
   default = {}
 }
 
 variable "context" {
-  type    = "map"
-  default = {}
+  type = object({
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    enabled             = bool
+    delimiter           = string
+    attributes          = list(string)
+    label_order         = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+  })
+  default = {
+    namespace           = ""
+    environment         = ""
+    stage               = ""
+    name                = ""
+    enabled             = true
+    delimiter           = ""
+    attributes          = []
+    label_order         = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = ""
+  }
 }
 
 variable "label_order" {
-  type    = "list"
+  type    = list(string)
   default = []
+}
+
+variable "regex_replace_chars" {
+  type    = string
+  default = "/[^a-zA-Z0-9-]/"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Fixes #9 

This includes a required upgrade of dependencies. The new version of label had an additional option (regex_replace_chars) that we didn't previously support, so that was added for consistency. Similar for the new defaults of the context variable.

I tested this by launching in a test account and confirming I could SSH from the bastion into testa.

Most of the upgrade was done by the `terraform 0.12upgrade` command.